### PR TITLE
Switch order of modal header elements

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -113,8 +113,7 @@ class Modal extends Widget
         echo Html::beginTag('div', $this->options) . "\n";
         echo Html::beginTag('div', ['class' => 'modal-dialog ' . $this->size]) . "\n";
         echo Html::beginTag('div', ['class' => 'modal-content']) . "\n";
-        echo $this->
-            () . "\n";
+        echo $this->renderHeader() . "\n";
         echo $this->renderBodyBegin() . "\n";
     }
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -113,7 +113,8 @@ class Modal extends Widget
         echo Html::beginTag('div', $this->options) . "\n";
         echo Html::beginTag('div', ['class' => 'modal-dialog ' . $this->size]) . "\n";
         echo Html::beginTag('div', ['class' => 'modal-content']) . "\n";
-        echo $this->renderHeader() . "\n";
+        echo $this->
+            () . "\n";
         echo $this->renderBodyBegin() . "\n";
     }
 
@@ -139,7 +140,7 @@ class Modal extends Widget
     {
         $button = $this->renderCloseButton();
         if ($button !== null) {
-            $this->header = $button . "\n" . $this->header;
+            $this->header = $this->header . "\n" . $button;
         }
         if ($this->header !== null) {
             Html::addCssClass($this->headerOptions, ['widget' => 'modal-header']);


### PR DESCRIPTION
According to https://getbootstrap.com/docs/4.0/components/modal, the order should be`modal-title`, then the close button. The way it is now, it doesn't display correctly.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes