### PR TITLE
[WIP] changes for Yii 3.0 asset system

### DIFF
--- a/composer.asset.json
+++ b/composer.asset.json
@@ -1,0 +1,11 @@
+{
+  "require": {
+    "bower-asset/bootstrap": "~4.0"
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    }
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -36,19 +36,12 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "~2.0|~2.1@dev|~3.0@dev",
-        "bower-asset/bootstrap": "~4.0"
+        "yiisoft/yii2": "~2.0|~2.1@dev|~3.0@dev"
     },
     "require-dev": {
         "yiisoft/yii2-coding-standards": "~2.0",
         "phpunit/phpunit": "*"
     },
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "yii\\bootstrap4\\": "src"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | ?

extracted asset packages into separate file

### Why?

If assets are specified in the `composer.json` file you have no chance to remove it later in your project or switch to `npm` for installing client side packages. Therefore it's necessary to remove them from the `composer.json` file. 

Specifying which in way assets are installed in your project should be part if the application template setup process. You are be able to choose from using `composer` (either with asset-packagist or asset-plugin) or `npm` (either via `foxy' or manually).

For development in the current stage you'd need to use commands similar to:

```
composer require wikimedia/composer-merge-plugin
composer config extra.merge-plugin.require "composer.asset.json"
composer update
```

... to use AP or...

```
composer require fxpio/foxy
composer update
```

... to use `npm`.

I know this is a huge change, but I felt it's time to come up with this important issue, before thing are way too much settled regarding extensions.