### PR TITLE
Fix tests for Tabs and ToggleButtonGroup

### DIFF
--- a/src/BaseHtml.php
+++ b/src/BaseHtml.php
@@ -169,8 +169,14 @@ class BaseHtml extends \yii\helpers\Html
                 $options['id'] = static::getId();
             }
 
-            $content = static::input($type, $name, $value, $options) . "\n";
-            $content .= static::label($label, $options['id'], $labelOptions);
+            $input = static::input($type, $name, $value, $options);
+
+            if (isset($labelOptions['wrapInput']) && $labelOptions['wrapInput']) {
+                unset($labelOptions['wrapInput']);
+                $content = static::label($input . $label, $options['id'], $labelOptions);
+            } else {
+                $content = $input . "\n" . static::label($label, $options['id'], $labelOptions);
+            }
             return $hidden . $content;
         }
 

--- a/src/ToggleButtonGroup.php
+++ b/src/ToggleButtonGroup.php
@@ -63,7 +63,7 @@ class ToggleButtonGroup extends InputWidget
     {
         parent::init();
         $this->registerPlugin('button');
-        Html::addCssClass($this->options, ['btn-group', 'btn-group-toggle']);
+        Html::addCssClass($this->options, ['btn-group']);
         $this->options['data-toggle'] = 'buttons';
     }
 
@@ -108,6 +108,7 @@ class ToggleButtonGroup extends InputWidget
     public function renderItem($index, $label, $name, $checked, $value)
     {
         $labelOptions = $this->labelOptions;
+        $labelOptions['wrapInput'] = true;
         Html::addCssClass($labelOptions, 'btn');
         if ($checked) {
             Html::addCssClass($labelOptions, 'active');
@@ -117,6 +118,7 @@ class ToggleButtonGroup extends InputWidget
             $label = Html::encode($label);
         }
         return Html::$type($name, $checked, [
+            'class'=>'d-none',
             'label' => $label,
             'labelOptions' => $labelOptions,
             'autocomplete' => 'off',

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -60,16 +60,16 @@ class TabsTest extends TestCase
             'w0', // nav widget container
                 "#$page1", // Page1
 
-                'w1', // Dropdown1
-                    "$page2", // Page2
-                    "$page3", // Page3
+            'w1', // Dropdown1
+                "$page2", // Page2
+                "$page3", // Page3
 
 
-                'w2', // Dropdown2
-                    "#$page4", // Page4
-                    "#$page5", // Page5
+            'w2', // Dropdown2
+                "#$page4", // Page4
+                "#$page5", // Page5
 
-                'w3', // Dropdown3
+            'w3', // Dropdown3
 
             // containers
             "id=\"$page1\"",
@@ -78,7 +78,7 @@ class TabsTest extends TestCase
             "id=\"$page4\"",
             "id=\"$page5\"",
             Html::a($extAnchor1, $extUrl1, ['class' => 'nav-link']),
-            Html::a($extAnchor2, $extUrl2, ['tabindex' => -1, 'class' => 'dropdown-item']),
+            Html::a($extAnchor2, $extUrl2, [/*'tabindex' => -1, */'class' => 'dropdown-item']),
         ];
 
         foreach ($shouldContain as $string) {
@@ -183,8 +183,9 @@ class TabsTest extends TestCase
                 ]
             ]
         ]);
-        $this->assertNotContains('<li class="active"><a href="#mytab-tab0" data-toggle="tab">Tab 1</a></li>', $html);
-        $this->assertContains('<li class="active"><a href="#mytab-tab1" data-toggle="tab">Tab 2</a></li>', $html);
+
+        $this->assertNotContains('<li class="nav-item"><a class="nav-link active" href="#mytab-tab0" aria-selected="true" data-toggle="tab" aria-controls="mytab-tab0">Tab 1</a></li>', $html);
+        $this->assertContains('<li class="nav-item"><a class="nav-link active" href="#mytab-tab1" aria-selected="true" data-toggle="tab" aria-controls="mytab-tab1">Tab 2</a></li>', $html);
     }
 
     public function testActivateTab()
@@ -212,6 +213,6 @@ class TabsTest extends TestCase
                 ]
             ]
         ]);
-        $this->assertContains('<li class="active"><a href="#mytab-tab2" data-toggle="tab">Tab 3</a></li>', $html);
+        $this->assertContains('<li class="nav-item"><a class="nav-link active" href="#mytab-tab2" aria-selected="true" data-toggle="tab" aria-controls="mytab-tab2">Tab 3</a></li>', $html);
     }
 }

--- a/tests/ToggleButtonGroupTest.php
+++ b/tests/ToggleButtonGroupTest.php
@@ -3,6 +3,8 @@
 namespace yiiunit\extensions\bootstrap4;
 
 use yii\base\Model;
+use yii\base\Widget;
+use yii\bootstrap4\ActiveField;
 use yii\bootstrap4\ToggleButtonGroup;
 
 /**
@@ -12,7 +14,7 @@ class ToggleButtonGroupTest extends TestCase
 {
     public function testCheckbox()
     {
-        ToggleButtonGroup::$counter = 0;
+        \yii\bootstrap4\Html::$counter = 0;
         $html = ToggleButtonGroup::widget([
             'type' => 'checkbox',
             'model' => new ToggleButtonGroupTestModel(),
@@ -24,15 +26,15 @@ class ToggleButtonGroupTest extends TestCase
         ]);
 
         $expectedHtml = <<<HTML
-<input type="hidden" name="ToggleButtonGroupTestModel[value]" value=""><div id="togglebuttongrouptestmodel-value" class="btn-group" data-toggle="buttons"><label class="btn"><input type="checkbox" name="ToggleButtonGroupTestModel[value][]" value="1"> item 1</label>
-<label class="btn"><input type="checkbox" name="ToggleButtonGroupTestModel[value][]" value="2"> item 2</label></div>
+<input type="hidden" name="ToggleButtonGroupTestModel[value]" value=""><div id="togglebuttongrouptestmodel-value" class="btn-group" data-toggle="buttons"><label class="btn" for="i0"><input type="checkbox" id="i0" class="d-none" name="ToggleButtonGroupTestModel[value][]" value="1" autocomplete="off">item 1</label>
+<label class="btn" for="i1"><input type="checkbox" id="i1" class="d-none" name="ToggleButtonGroupTestModel[value][]" value="2" autocomplete="off">item 2</label></div>
 HTML;
         $this->assertEqualsWithoutLE($expectedHtml, $html);
     }
 
     public function testRadio()
     {
-        ToggleButtonGroup::$counter = 0;
+        \yii\bootstrap4\Html::$counter = 0;
         $html = ToggleButtonGroup::widget([
             'type' => 'radio',
             'model' => new ToggleButtonGroupTestModel(),
@@ -44,8 +46,8 @@ HTML;
         ]);
 
         $expectedHtml = <<<HTML
-<input type="hidden" name="ToggleButtonGroupTestModel[value]" value=""><div id="togglebuttongrouptestmodel-value" class="btn-group" data-toggle="buttons"><label class="btn"><input type="radio" name="ToggleButtonGroupTestModel[value]" value="1"> item 1</label>
-<label class="btn"><input type="radio" name="ToggleButtonGroupTestModel[value]" value="2"> item 2</label></div>
+<input type="hidden" name="ToggleButtonGroupTestModel[value]" value=""><div id="togglebuttongrouptestmodel-value" class="btn-group" data-toggle="buttons"><label class="btn" for="i0"><input type="radio" id="i0" class="d-none" name="ToggleButtonGroupTestModel[value]" value="1" autocomplete="off">item 1</label>
+<label class="btn" for="i1"><input type="radio" id="i1" class="d-none" name="ToggleButtonGroupTestModel[value]" value="2" autocomplete="off">item 2</label></div>
 HTML;
         $this->assertEqualsWithoutLE($expectedHtml, $html);
     }


### PR DESCRIPTION
Makes tests pass and introduces a new option `wrapInput` to wrap input
elements inside label elements.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #60, #61
