### PR TITLE
Fixed accordion rendering (fix #72)

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -116,6 +116,7 @@ class Accordion extends Widget
     public function run()
     {
         $this->registerPlugin('collapse');
+        Html::addCssClass($this->options, 'accordion');
         return implode("\n", [
                 Html::beginTag('div', $this->options),
                 $this->renderItems(),
@@ -189,10 +190,6 @@ class Accordion extends Widget
                 'aria-controls' => $options['id']
             ], $this->itemToggleOptions);
 
-            if ($this->autoCloseItems) {
-                $itemToggleOptions['data-parent'] = '#' . $this->options['id'];
-            }
-
             $itemToggleTag = ArrayHelper::remove($itemToggleOptions, 'tag', 'button');
             if ($itemToggleTag === 'a') {
                 ArrayHelper::remove($itemToggleOptions, 'data-target');
@@ -225,6 +222,10 @@ class Accordion extends Widget
             throw new InvalidConfigException('The "content" option is required.');
         }
         $group = [];
+
+        if ($this->autoCloseItems) {
+            $options['data-parent'] = '#' . $this->options['id'];
+        }
 
         $group[] = Html::tag('div', $header, ['class' => 'card-header', 'id' => $options['id'] . '-heading']);
         $group[] = Html::beginTag('div', $options);

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -2,18 +2,18 @@
 namespace yiiunit\extensions\bootstrap4;
 
 use yii\base\DynamicModel;
-use yii\bootstrap4\Collapse;
+use yii\bootstrap4\Accordion;
 use yii\widgets\ActiveForm;
 
 /**
  * @group bootstrap4
  */
-class CollapseTest extends TestCase
+class AccordionTest extends TestCase
 {
     public function testRender()
     {
-        Collapse::$counter = 0;
-        $output = Collapse::widget([
+        Accordion::$counter = 0;
+        $output = Accordion::widget([
             'items' => [
                 [
                     'label' => 'Collapsible Group Item #1',
@@ -70,26 +70,26 @@ class CollapseTest extends TestCase
         ]);
 
         $this->assertEqualsWithoutLE(<<<HTML
-<div id="w0">
-<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0" data-parent="#w0">Collapsible Group Item #1</button>
+<div id="w0" class="accordion">
+<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0">Collapsible Group Item #1</button>
 </h5></div>
-<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading">
+<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading" data-parent="#w0">
 <ul class="list-group">
 <li class="list-group-item">test content1</li>
 <li class="list-group-item">test content2</li>
 </ul>
 
 </div></div>
-<div id="testId" class="testClass card"><div id="w0-collapse1-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w2" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse1" aria-controls="w0-collapse1" data-parent="#w0">Collapsible Group Item #2</button>
+<div id="testId" class="testClass card"><div id="w0-collapse1-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w2" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse1" aria-controls="w0-collapse1">Collapsible Group Item #2</button>
 </h5></div>
-<div id="w0-collapse1" class="testContentOptions collapse" aria-labelledby="w0-collapse1-heading">
+<div id="w0-collapse1" class="testContentOptions collapse" aria-labelledby="w0-collapse1-heading" data-parent="#w0">
 <div class="card-body">Das ist das Haus vom Nikolaus</div>
 
 <div class="card-footer">Footer</div>
 </div></div>
-<div id="testId2" class="testClass2 card"><div id="w0-collapse2-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w3" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse2" aria-controls="w0-collapse2" data-parent="#w0"><h1>Collapsible Group Item #3</h1></button>
+<div id="testId2" class="testClass2 card"><div id="w0-collapse2-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w3" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse2" aria-controls="w0-collapse2"><h1>Collapsible Group Item #3</h1></button>
 </h5></div>
-<div id="w0-collapse2" class="testContentOptions2 collapse" aria-labelledby="w0-collapse2-heading">
+<div id="w0-collapse2" class="testContentOptions2 collapse" aria-labelledby="w0-collapse2-heading" data-parent="#w0">
 <ul class="list-group">
 <li class="list-group-item"><h2>test content1</h2></li>
 <li class="list-group-item"><h2>test content2</h2></li>
@@ -97,9 +97,9 @@ class CollapseTest extends TestCase
 
 <div class="card-footer">Footer2</div>
 </div></div>
-<div id="testId3" class="testClass3 card"><div id="w0-collapse3-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w4" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse3" aria-controls="w0-collapse3" data-parent="#w0">&lt;h1&gt;Collapsible Group Item #4&lt;/h1&gt;</button>
+<div id="testId3" class="testClass3 card"><div id="w0-collapse3-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w4" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse3" aria-controls="w0-collapse3">&lt;h1&gt;Collapsible Group Item #4&lt;/h1&gt;</button>
 </h5></div>
-<div id="w0-collapse3" class="testContentOptions3 collapse" aria-labelledby="w0-collapse3-heading">
+<div id="w0-collapse3" class="testContentOptions3 collapse" aria-labelledby="w0-collapse3-heading" data-parent="#w0">
 <ul class="list-group">
 <li class="list-group-item"><h2>test content1</h2></li>
 <li class="list-group-item"><h2>test content2</h2></li>
@@ -120,8 +120,8 @@ HTML
         ActiveForm::end();
         ob_end_clean();
 
-        Collapse::$counter = 0;
-        $output = Collapse::widget([
+        Accordion::$counter = 0;
+        $output = Accordion::widget([
             'items' => [
                 'Item1' => 'Content1',
                 'Item2' => [
@@ -136,28 +136,28 @@ HTML
         ]);
 
         $this->assertEqualsWithoutLE(<<<HTML
-<div id="w0">
-<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0" data-parent="#w0">Item1</button>
+<div id="w0" class="accordion">
+<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0">Item1</button>
 </h5></div>
-<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading">
+<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading" data-parent="#w0">
 <div class="card-body">Content1</div>
 
 </div></div>
-<div class="card"><div id="w0-collapse1-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w2" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse1" aria-controls="w0-collapse1" data-parent="#w0">Item2</button>
+<div class="card"><div id="w0-collapse1-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w2" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse1" aria-controls="w0-collapse1">Item2</button>
 </h5></div>
-<div id="w0-collapse1" class="collapse" aria-labelledby="w0-collapse1-heading">
+<div id="w0-collapse1" class="collapse" aria-labelledby="w0-collapse1-heading" data-parent="#w0">
 <div class="card-body">Content2</div>
 
 </div></div>
-<div class="card"><div id="w0-collapse2-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w3" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse2" aria-controls="w0-collapse2" data-parent="#w0">Item3</button>
+<div class="card"><div id="w0-collapse2-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w3" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse2" aria-controls="w0-collapse2">Item3</button>
 </h5></div>
-<div id="w0-collapse2" class="collapse" aria-labelledby="w0-collapse2-heading">
+<div id="w0-collapse2" class="collapse" aria-labelledby="w0-collapse2-heading" data-parent="#w0">
 <div class="card-body">Content3</div>
 
 </div></div>
-<div class="card"><div id="w0-collapse3-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w4" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse3" aria-controls="w0-collapse3" data-parent="#w0">FormField</button>
+<div class="card"><div id="w0-collapse3-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w4" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse3" aria-controls="w0-collapse3">FormField</button>
 </h5></div>
-<div id="w0-collapse3" class="collapse" aria-labelledby="w0-collapse3-heading">
+<div id="w0-collapse3" class="collapse" aria-labelledby="w0-collapse3-heading" data-parent="#w0">
 <div class="card-body"><div class="form-group field-dynamicmodel-test">
 <input type="text" id="dynamicmodel-test" class="form-control" name="DynamicModel[test]">
 </div></div>
@@ -184,7 +184,7 @@ HTML
      */
     public function testMissingLabel($items)
     {
-        Collapse::widget([
+        Accordion::widget([
             'items' => $items,
         ]);
     }
@@ -201,8 +201,8 @@ HTML
         ob_end_clean();
         $model = new data\Singer;
 
-        Collapse::$counter = 0;
-        $output = Collapse::widget([
+        Accordion::$counter = 0;
+        $output = Accordion::widget([
             'items' => [
                 [
                     'label' => 'Collapsible Group Item #1',
@@ -212,10 +212,10 @@ HTML
         ]);
 
         $this->assertEqualsWithoutLE(<<<HTML
-<div id="w0">
-<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0" data-parent="#w0">Collapsible Group Item #1</button>
+<div id="w0" class="accordion">
+<div class="card"><div id="w0-collapse0-heading" class="card-header"><h5 class="mb-0"><button type="button" id="w1" class="btn-link btn" data-toggle="collapse" data-target="#w0-collapse0" aria-expanded aria-controls="w0-collapse0">Collapsible Group Item #1</button>
 </h5></div>
-<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading">
+<div id="w0-collapse0" class="collapse show" aria-labelledby="w0-collapse0-heading" data-parent="#w0">
 <div class="card-body"><div class="form-group field-singer-firstname">
 <input type="text" id="singer-firstname" class="form-control" name="Singer[firstName]">
 </div></div>
@@ -240,11 +240,11 @@ HTML
             ],
         ];
 
-        $output = Collapse::widget([
+        $output = Accordion::widget([
             'items' => $items
         ]);
         $this->assertContains('data-parent="', $output);
-        $output = Collapse::widget([
+        $output = Accordion::widget([
             'autoCloseItems' => false,
             'items' => $items
         ]);
@@ -267,9 +267,9 @@ HTML
             ],
         ];
 
-        Collapse::$counter = 0;
+        Accordion::$counter = 0;
 
-        $output = Collapse::widget([
+        $output = Accordion::widget([
             'items' => $items,
             'itemToggleOptions' => [
                 'tag' => 'a',
@@ -279,7 +279,7 @@ HTML
         $this->assertContains('<h5 class="mb-0"><a type="button" class="custom-toggle" href="#w0-collapse0" ', $output);
         $this->assertNotContains('<button', $output);
 
-        $output = Collapse::widget([
+        $output = Accordion::widget([
             'items' => $items,
             'itemToggleOptions' => [
                 'tag' => 'a',


### PR DESCRIPTION
added missing css class "accordion" to wrapping div
renamed test to `AccordionTest` to match class name `Accordion`

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #72 
