### PR TITLE
Fix Tabs::$encodeLabel that wasn't taken into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 2.0.1 under development
 -----------------------
 
+- Bug #108: Tabs::$encodeLabels was not considered when encoding labels (machour)
 - Bug #137: Remove role="navigation" from yii\bootstrap4\NavBar according to aria specification (Thoulah)
 
 

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -156,7 +156,8 @@ class Tabs extends Widget
         return Nav::widget([
                 'dropdownClass' => $this->dropdownClass,
                 'options' => $this->options,
-                'items' => $this->items
+                'items' => $this->items,
+                'encodeLabels' => $this->encodeLabels,
             ]) . $this->renderPanes($this->panes);
     }
 

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -230,4 +230,30 @@ class TabsTest extends TestCase
         $this->assertContains('<li class="nav-item active"><a class="nav-link active" href="#mytab-tab2" data-toggle="tab" role="tab" aria-controls="mytab-tab2" aria-selected="true">Tab 3</a></li>',
             $html);
     }
+
+    public function testTabLabelEncoding()
+    {
+        $html = Tabs::widget([
+            'encodeLabels' => false,
+            'id' => 'mytab',
+            'items' => [
+                [
+                    'label' => 'Tab 1<span>encoded</span>',
+                    'content' => 'some content',
+                    'encode' => true,
+                ],
+                [
+                    'label' => 'Tab 2<span>not encoded</span>',
+                    'content' => 'some content',
+                ],
+                [
+                    'label' => 'Tab 3<span>not encoded too</span>',
+                    'content' => 'some content',
+                ],
+            ]
+        ]);
+        $this->assertContains('&lt;span&gt;encoded&lt;/span&gt;', $html);
+        $this->assertContains('<span>not encoded</span>', $html);
+        $this->assertContains('<span>not encoded too</span>', $html);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #108 partially

`encodeLabels` wasn't transmitted to the `Nav` component