### PR TITLE
Disabling the assets registering

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -116,7 +116,10 @@ class Accordion extends Widget
      */
     public function run()
     {
-        $this->registerPlugin('collapse');
+        if ($this->registerWidget) {
+            $this->registerPlugin('collapse');
+        }
+
         Html::addCssClass($this->options, 'accordion');
         return implode("\n", [
                 Html::beginTag('div', $this->options),

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -88,7 +88,9 @@ class Alert extends Widget
         echo "\n" . $this->renderBodyEnd();
         echo "\n" . Html::endTag('div');
 
-        $this->registerPlugin('alert');
+        if ($this->registerWidget) {
+            $this->registerPlugin('alert');
+        }
     }
 
     /**

--- a/src/BootstrapWidgetTrait.php
+++ b/src/BootstrapWidgetTrait.php
@@ -47,6 +47,12 @@ trait BootstrapWidgetTrait
      */
     public $clientEvents = [];
 
+    /**
+     * Option to disable the css and js of the specific plugin to allow the use of custom bundled assets from other files.
+     *
+     * @var bool
+     */
+    public $registerWidget = true;
 
     /**
      * Initializes the widget.

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -93,7 +93,9 @@ class Breadcrumbs extends Widget
      */
     public function run()
     {
-        $this->registerPlugin('breadcrumb');
+        if ($this->registerWidget) {
+            $this->registerPlugin('breadcrumb');
+        }
 
         if (empty($this->links)) {
             return '';

--- a/src/Button.php
+++ b/src/Button.php
@@ -53,7 +53,10 @@ class Button extends Widget
      */
     public function run()
     {
-        $this->registerPlugin('button');
+        if ($this->registerWidget) {
+            $this->registerPlugin('button');
+        }
+
         return Html::tag($this->tagName, $this->encodeLabel ? Html::encode($this->label) : $this->label,
             $this->options);
     }

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -130,7 +130,10 @@ class ButtonDropdown extends Widget
         // Set options id to button options id to ensure correct css selector in plugin initialisation
         $this->options['id'] = $this->buttonOptions['id'];
 
-        $this->registerPlugin('dropdown');
+        if ($this->registerWidget) {
+            $this->registerPlugin('dropdown');
+        }
+
         return $html;
     }
 

--- a/src/ButtonGroup.php
+++ b/src/ButtonGroup.php
@@ -76,7 +76,10 @@ class ButtonGroup extends Widget
      */
     public function run()
     {
-        BootstrapAsset::register($this->getView());
+        if ($this->registerWidget) {
+            BootstrapAsset::register($this->getView());
+        }
+
         return Html::tag('div', $this->renderButtons(), $this->options);
     }
 

--- a/src/ButtonToolbar.php
+++ b/src/ButtonToolbar.php
@@ -81,7 +81,10 @@ class ButtonToolbar extends Widget
      */
     public function run()
     {
-        BootstrapAsset::register($this->getView());
+        if ($this->registerWidget) {
+            BootstrapAsset::register($this->getView());
+        }
+
         return Html::tag('div', $this->renderButtonGroups(), $this->options);
     }
 

--- a/src/Carousel.php
+++ b/src/Carousel.php
@@ -95,7 +95,10 @@ class Carousel extends Widget
      */
     public function run()
     {
-        $this->registerPlugin('carousel');
+        if ($this->registerWidget) {
+            $this->registerPlugin('carousel');
+        }
+
         return implode("\n", [
                 Html::beginTag('div', $this->options),
                 $this->renderIndicators(),

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -78,8 +78,11 @@ class Dropdown extends Widget
      */
     public function run()
     {
-        BootstrapPluginAsset::register($this->getView());
-        $this->registerClientEvents();
+        if ($this->registerWidget) {
+            BootstrapPluginAsset::register($this->getView());
+            $this->registerClientEvents();
+        }
+
         return $this->renderItems($this->items, $this->options);
     }
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -139,7 +139,9 @@ class Modal extends Widget
         echo "\n" . Html::endTag('div'); // modal-dialog
         echo "\n" . Html::endTag('div');
 
-        $this->registerPlugin('modal');
+        if ($this->registerWidget) {
+            $this->registerPlugin('modal');
+        }
     }
 
     /**

--- a/src/Nav.php
+++ b/src/Nav.php
@@ -125,7 +125,10 @@ class Nav extends Widget
      */
     public function run()
     {
-        BootstrapAsset::register($this->getView());
+        if ($this->registerWidget) {
+            BootstrapAsset::register($this->getView());
+        }
+
         return $this->renderItems();
     }
 

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -168,7 +168,9 @@ class NavBar extends Widget
         }
         $tag = ArrayHelper::remove($this->options, 'tag', 'nav');
         echo Html::endTag($tag);
-        BootstrapPluginAsset::register($this->getView());
+        if ($this->registerWidget) {
+            BootstrapPluginAsset::register($this->getView());
+        }
     }
 
     /**

--- a/src/Progress.php
+++ b/src/Progress.php
@@ -101,7 +101,10 @@ class Progress extends Widget
      */
     public function run()
     {
-        BootstrapAsset::register($this->getView());
+        if ($this->registerWidget) {
+            BootstrapAsset::register($this->getView());
+        }
+        
         return $this->renderProgress();
     }
 

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -151,7 +151,10 @@ class Tabs extends Widget
      */
     public function run()
     {
-        $this->registerPlugin('tab');
+        if ($this->registerWidget) {
+            $this->registerPlugin('tab');
+        }
+
         $this->prepareItems($this->items);
         return Nav::widget([
                 'dropdownClass' => $this->dropdownClass,

--- a/src/ToggleButtonGroup.php
+++ b/src/ToggleButtonGroup.php
@@ -70,7 +70,10 @@ class ToggleButtonGroup extends InputWidget
     public function init()
     {
         parent::init();
-        $this->registerPlugin('button');
+        if ($this->registerWidget) {
+            $this->registerPlugin('button');
+        }
+
         Html::addCssClass($this->options, ['widget' => 'btn-group-toggle']);
         $this->options['data-toggle'] = 'buttons';
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

This pull request is both the bugfix and feature which allow us to use custom bootstrap 4 based css and js which we could import to our html without using the version of the assets in the widget.

```
<html>
<head>
<link href="/css/bootstrap.css" rel="stylesheet">
<link href="/css/app.css" rel="stylesheet">
</head>
<body>
//other codes
<script src="/js/app.js"></script>
</body>
</html>

```

The issue is when we use this approach to import the **Breadcrumbs widget**. Our custom js doesn't work when we import that widget. Disabling the css and js imported from the widget fixed the issue. 

**Usage:**

```
   <?= yii\bootstrap4\Breadcrumbs::widget([
       'registerWidget' => false,
    ]); ?>
```