### PR TITLE
Restoring functional itemOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 - Bug #131: Fixed element with role tab must be inside role tablist (simialbi)
 - Enh #129: Added `Modal::SIZE_EXTRA_LARGE` constant (shoomlix)
 - Enh #137: Added disabled option for Nav, Dropdown and Tabs (Thoulah)
-- Bug #138: Restored functional itemOptions in Dropdown
+- Bug #138: Restored functional itemOptions in Dropdown (Thoulah)
 
 
 2.0.2 April 30, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 - Bug #131: Fixed element with role tab must be inside role tablist (simialbi)
 - Enh #129: Added `Modal::SIZE_EXTRA_LARGE` constant (shoomlix)
 - Enh #137: Added disabled option for Nav, Dropdown and Tabs (Thoulah)
+- Bug #138: Restored functional itemOptions in Dropdown
 
 
 2.0.2 April 30, 2019

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -110,6 +110,7 @@ class Dropdown extends Widget
             }
             $encodeLabel = isset($item['encode']) ? $item['encode'] : $this->encodeLabels;
             $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
+            $itemOptions = ArrayHelper::getValue($item, 'options', []);
             $linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
             $disabled = ArrayHelper::getValue($item, 'disabled', false);
 
@@ -136,7 +137,7 @@ class Dropdown extends Widget
                 Html::addCssClass($submenuOptions, ['dropdown-submenu']);
                 Html::addCssClass($linkOptions, ['dropdown-toggle']);
 
-                $lines[] = Html::beginTag('div', ['class' => ['dropdown'], 'aria-expanded' => 'false']);
+                $lines[] = Html::beginTag('div', array_merge_recursive(['class' => ['dropdown'], 'aria-expanded' => 'false'], $itemOptions));
                 $lines[] = Html::a($label, $url, array_merge([
                     'data-toggle' => 'dropdown',
                     'aria-haspopup' => 'true',

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -327,7 +327,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="dropdown nav-item active"><a class="dropdown-toggle nav-link active" href="#" data-toggle="dropdown">Dropdown</a><div id="w1" class="dropdown-menu"><div class="dropdown" aria-expanded="false">
+<ul id="w0" class="nav"><li class="dropdown nav-item active"><a class="dropdown-toggle nav-link active" href="#" data-toggle="dropdown">Dropdown</a><div id="w1" class="dropdown-menu"><div class="dropdown active" aria-expanded="false">
 <a class="dropdown-item dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Sub-dropdown</a>
 <div id="w2" class="dropdown-submenu dropdown-menu"><h6 class="dropdown-header">Page</h6></div>
 </div></div></li></ul>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Probably, not sure
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

As I found `$itemOptions` doing nothing in previous PR, I dug a little deeper and found the original meaning. I restored the functionality.