### PR TITLE
Do not hardcode container CSS class

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -75,6 +75,11 @@ class Breadcrumbs extends Widget
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
     public $navOptions = ['aria-label' => 'breadcrumb'];
+    /**
+     * @var string CSS class added to widget container
+     * @since 2.0.7
+     */
+    public $containerClass = 'breadcrumb';
 
 
     /**
@@ -85,7 +90,9 @@ class Breadcrumbs extends Widget
     {
         parent::init();
         $this->clientOptions = false;
-        Html::addCssClass($this->options, ['widget' => 'breadcrumb']);
+        if ($this->containerClass) {
+            Html::addCssClass($this->options, ['widget' => $this->containerClass]);
+        }
     }
 
     /**


### PR DESCRIPTION
### What steps will reproduce the problem?

Custom templates for breadcrumbs may use different container class, than currently hard-coded `breadcrumb`.

### What's expected?

Make CSS class name configurable - extract as a public property.

### What do you get instead?

Mixed up default BS4 classes & custom template classes. Additional `Html::removeCssClass(options, 'breadcrumbs')` must be called to fix the isssue.

| Q                | A
| ---------------- | ---
| Yii version       | 2.0.22
| PHP version      | 7.0.33
| Operating system | Win/CentOS

Issue #160 .