### PR TITLE
Changed checkbox and radio options behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 2.0.7 under development
 -----------------------
 
+- Enh #165: Allow override all classes via widget factory (simialbi)
 - Bug #163: Fixed error messages for checkbox and radio lists (simialbi)
 
 

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -114,6 +114,21 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public $inputOptions = ['class' => ['widget' => 'form-control']];
     /**
+     * @var array the default options for the input tags (checkboxes and radios). The parameter passed to individual
+     * input methods (e.g. [[textInput()]]) will be merged with this property when rendering the input tag.
+     *
+     * If you set a custom `id` for the input element, you may need to adjust the [[$selectors]] accordingly.
+     *
+     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     * @since 2.0.7
+     */
+    public $checkOptions = [
+        'class' => ['widget' => 'custom-control-input'],
+        'labelOptions' => [
+            'class' => ['widget' => 'custom-control-label']
+        ]
+    ];
+    /**
      * {@inheritdoc}
      */
     public $errorOptions = ['class' => 'invalid-feedback'];
@@ -221,9 +236,13 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public function checkbox($options = [], $enclosedByLabel = false)
     {
+        $checkOptions = $this->checkOptions;
+        $options = ArrayHelper::merge($checkOptions, $options);
         Html::removeCssClass($options, 'form-control');
-        Html::addCssClass($options, 'custom-control-input');
-        Html::addCssClass($this->labelOptions, 'custom-control-label');
+        $labelOptions = ArrayHelper::remove($options, 'labelOptions', []);
+        $wrapperOptions = ArrayHelper::remove($options, 'wrapperOptions', []);
+        $this->labelOptions = ArrayHelper::merge($this->labelOptions, $labelOptions);
+        $this->wrapperOptions = ArrayHelper::merge($this->wrapperOptions, $wrapperOptions);
 
         if (!isset($options['template'])) {
             $this->template = ($enclosedByLabel) ? $this->checkEnclosedTemplate : $this->checkTemplate;
@@ -253,9 +272,13 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public function radio($options = [], $enclosedByLabel = false)
     {
+        $checkOptions = $this->checkOptions;
+        $options = ArrayHelper::merge($checkOptions, $options);
         Html::removeCssClass($options, 'form-control');
-        Html::addCssClass($options, 'custom-control-input');
-        Html::addCssClass($this->labelOptions, 'custom-control-label');
+        $labelOptions = ArrayHelper::remove($options, 'labelOptions', []);
+        $wrapperOptions = ArrayHelper::remove($options, 'wrapperOptions', []);
+        $this->labelOptions = ArrayHelper::merge($this->labelOptions, $labelOptions);
+        $this->wrapperOptions = ArrayHelper::merge($this->wrapperOptions, $wrapperOptions);
 
         if (!isset($options['template'])) {
             $this->template = $enclosedByLabel ? $this->checkEnclosedTemplate : $this->radioTemplate;
@@ -287,25 +310,22 @@ class ActiveField extends \yii\widgets\ActiveField
             $this->template = str_replace("\n{error}", '', $this->template);
             $itemOptions = isset($options['itemOptions']) ? $options['itemOptions'] : [];
             $encode = ArrayHelper::getValue($options, 'encode', true);
-            $wrapperOptions = ['class' => ['custom-control', 'custom-checkbox']];
             $itemCount = count($items) - 1;
             $error = $this->error()->parts['{error}'];
-            if ($this->inline) {
-                Html::addCssClass($wrapperOptions, 'custom-control-inline');
-            }
             $options['item'] = function ($i, $label, $name, $checked, $value) use (
                 $itemOptions,
                 $encode,
-                $wrapperOptions,
                 $itemCount,
                 $error
             ) {
-                $options = array_merge([
-                    'class' => 'custom-control-input',
+                $options = array_merge($this->checkOptions, [
                     'label' => $encode ? Html::encode($label) : $label,
-                    'labelOptions' => ['class' => 'custom-control-label'],
                     'value' => $value
                 ], $itemOptions);
+                $wrapperOptions = ArrayHelper::remove($options, 'wrapperOptions', ['class' => ['custom-control', 'custom-checkbox']]);
+                if ($this->inline) {
+                    Html::addCssClass($wrapperOptions, 'custom-control-inline');
+                }
 
                 $html = Html::beginTag('div', $wrapperOptions) . "\n" .
                     Html::checkbox($name, $checked, $options) . "\n";
@@ -331,25 +351,22 @@ class ActiveField extends \yii\widgets\ActiveField
             $this->template = str_replace("\n{error}", '', $this->template);
             $itemOptions = isset($options['itemOptions']) ? $options['itemOptions'] : [];
             $encode = ArrayHelper::getValue($options, 'encode', true);
-            $wrapperOptions = ['class' => ['custom-control', 'custom-radio']];
             $itemCount = count($items) - 1;
             $error = $this->error()->parts['{error}'];
-            if ($this->inline) {
-                Html::addCssClass($wrapperOptions, 'custom-control-inline');
-            }
             $options['item'] = function ($i, $label, $name, $checked, $value) use (
                 $itemOptions,
                 $encode,
-                $wrapperOptions,
                 $itemCount,
                 $error
             ) {
-                $options = array_merge([
-                    'class' => 'custom-control-input',
+                $options = array_merge($this->checkOptions, [
                     'label' => $encode ? Html::encode($label) : $label,
-                    'labelOptions' => ['class' => 'custom-control-label'],
                     'value' => $value
                 ], $itemOptions);
+                $wrapperOptions = ArrayHelper::remove($options, 'wrapperOptions', ['class' => ['custom-control', 'custom-radio']]);
+                if ($this->inline) {
+                    Html::addCssClass($wrapperOptions, 'custom-control-inline');
+                }
 
                 $html = Html::beginTag('div', $wrapperOptions) . "\n" .
                     Html::radio($name, $checked, $options) . "\n";
@@ -453,6 +470,9 @@ class ActiveField extends \yii\widgets\ActiveField
             ],
             'inputOptions' => [
                 'class' => 'form-control'
+            ],
+            'labelOptions' => [
+                'class' => []
             ]
         ];
 

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -114,8 +114,8 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public $inputOptions = ['class' => ['widget' => 'form-control']];
     /**
-     * @var array the default options for the checkboxes. The parameter passed to individual
-     * input methods (e.g. [[textInput()]]) will be merged with this property when rendering the input tag.
+     * @var array the default options for the input checkboxes. The parameter passed to individual
+     * input methods (e.g. [[checkbox()]]) will be merged with this property when rendering the input tag.
      *
      * If you set a custom `id` for the input element, you may need to adjust the [[$selectors]] accordingly.
      *
@@ -130,7 +130,7 @@ class ActiveField extends \yii\widgets\ActiveField
     ];
     /**
      * @var array the default options for the input radios. The parameter passed to individual
-     * input methods (e.g. [[textInput()]]) will be merged with this property when rendering the input tag.
+     * input methods (e.g. [[radio()]]) will be merged with this property when rendering the input tag.
      *
      * If you set a custom `id` for the input element, you may need to adjust the [[$selectors]] accordingly.
      *

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -114,7 +114,7 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public $inputOptions = ['class' => ['widget' => 'form-control']];
     /**
-     * @var array the default options for the input tags (checkboxes and radios). The parameter passed to individual
+     * @var array the default options for the checkboxes. The parameter passed to individual
      * input methods (e.g. [[textInput()]]) will be merged with this property when rendering the input tag.
      *
      * If you set a custom `id` for the input element, you may need to adjust the [[$selectors]] accordingly.
@@ -123,6 +123,21 @@ class ActiveField extends \yii\widgets\ActiveField
      * @since 2.0.7
      */
     public $checkOptions = [
+        'class' => ['widget' => 'custom-control-input'],
+        'labelOptions' => [
+            'class' => ['widget' => 'custom-control-label']
+        ]
+    ];
+    /**
+     * @var array the default options for the input radios. The parameter passed to individual
+     * input methods (e.g. [[textInput()]]) will be merged with this property when rendering the input tag.
+     *
+     * If you set a custom `id` for the input element, you may need to adjust the [[$selectors]] accordingly.
+     *
+     * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
+     * @since 2.0.7
+     */
+    public $radioOptions = [
         'class' => ['widget' => 'custom-control-input'],
         'labelOptions' => [
             'class' => ['widget' => 'custom-control-label']
@@ -272,7 +287,7 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public function radio($options = [], $enclosedByLabel = false)
     {
-        $checkOptions = $this->checkOptions;
+        $checkOptions = $this->radioOptions;
         $options = ArrayHelper::merge($checkOptions, $options);
         Html::removeCssClass($options, 'form-control');
         $labelOptions = ArrayHelper::remove($options, 'labelOptions', []);
@@ -359,7 +374,7 @@ class ActiveField extends \yii\widgets\ActiveField
                 $itemCount,
                 $error
             ) {
-                $options = array_merge($this->checkOptions, [
+                $options = array_merge($this->radioOptions, [
                     'label' => $encode ? Html::encode($label) : $label,
                     'value' => $value
                 ], $itemOptions);

--- a/tests/ActiveFieldDefaultFormCheckTest.php
+++ b/tests/ActiveFieldDefaultFormCheckTest.php
@@ -55,6 +55,15 @@ class ActiveFieldDefaultFormCheckTest extends TestCase
                             'wrapperOptions' => [
                                 'class' => ['widget' => 'form-check']
                             ]
+                        ],
+                        'radioOptions' => [
+                            'class' => ['widget' => 'form-check-input'],
+                            'labelOptions' => [
+                                'class' => ['widget' => 'form-check-label']
+                            ],
+                            'wrapperOptions' => [
+                                'class' => ['widget' => 'form-check']
+                            ]
                         ]
                     ]
                 ]

--- a/tests/ActiveFieldDefaultFormCheckTest.php
+++ b/tests/ActiveFieldDefaultFormCheckTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * @package yii2-bootstrap4
+ * @author Simon Karlen <simi.albi@outlook.com>
+ * @copyright Copyright © 2019 Simon Karlen
+ */
+
+namespace yiiunit\extensions\bootstrap4;
+
+use Yii;
+use yii\base\DynamicModel;
+use yii\bootstrap4\ActiveField;
+use yii\bootstrap4\ActiveForm;
+use yii\bootstrap4\Html;
+use yii\helpers\UnsetArrayValue;
+
+class ActiveFieldDefaultFormCheckTest extends TestCase
+{
+    /**
+     * @var ActiveField
+     */
+    private $_activeField;
+    /**
+     * @var DynamicModel
+     */
+    private $_helperModel;
+    /**
+     * @var ActiveForm
+     */
+    private $_helperForm;
+    /**
+     * @var string
+     */
+    private $_attributeName = 'attributeName';
+
+    protected function setUp()
+    {
+        // dirty way to have Request object not throwing exception when running testHomeLinkNull()
+        $_SERVER['SCRIPT_FILENAME'] = 'index.php';
+        $_SERVER['SCRIPT_NAME'] = 'index.php';
+
+        $this->mockWebApplication([
+            'container' => [
+                'definitions' => [
+                    'yii\bootstrap4\ActiveField' => [
+                        'checkTemplate' => "<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>",
+                        'radioTemplate' => "<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>",
+                        'checkHorizontalTemplate' => "{beginWrapper}\n<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>\n{endWrapper}",
+                        'radioHorizontalTemplate' => "{beginWrapper}\n<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>\n{endWrapper}",
+                        'checkOptions' => [
+                            'class' => ['widget' => 'form-check-input'],
+                            'labelOptions' => [
+                                'class' => ['widget' => 'form-check-label']
+                            ],
+                            'wrapperOptions' => [
+                                'class' => ['widget' => 'form-check']
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->_helperModel = new DynamicModel(['attributeName']);
+        ob_start();
+        $this->_helperForm = ActiveForm::begin(['action' => '/something']);
+        ActiveForm::end();
+        ob_end_clean();
+
+        $this->_activeField = Yii::createObject([
+            'class' => 'yii\bootstrap4\ActiveField',
+            'form' => $this->_helperForm
+        ]);
+        $this->_activeField->model = $this->_helperModel;
+        $this->_activeField->attribute = $this->_attributeName;
+    }
+
+    public function testDefaultCheckboxByConfig()
+    {
+        Html::$counter = 0;
+        $this->_activeField->inline = true;
+        $html = $this->_activeField->checkbox()->render();
+
+        $expectedHtml = <<<HTML
+<div class="form-group field-dynamicmodel-attributename">
+<div class="form-check">
+<input type="hidden" name="DynamicModel[attributeName]" value="0"><input type="checkbox" id="dynamicmodel-attributename" class="form-check-input" name="DynamicModel[attributeName]" value="1">
+<label class="form-check-label" for="dynamicmodel-attributename">Attribute Name</label>
+<div class="invalid-feedback"></div>
+
+</div>
+</div>
+HTML;
+        $this->assertEqualsWithoutLE($expectedHtml, $html);
+    }
+
+    public function testDefaultRadioByConfig()
+    {
+        Html::$counter = 0;
+        $this->_activeField->inline = true;
+        $html = $this->_activeField->radio()->render();
+
+        $expectedHtml = <<<HTML
+<div class="form-group field-dynamicmodel-attributename">
+<div class="form-check">
+<input type="hidden" name="DynamicModel[attributeName]" value="0"><input type="radio" id="dynamicmodel-attributename" class="form-check-input" name="DynamicModel[attributeName]" value="1">
+<label class="form-check-label" for="dynamicmodel-attributename">Attribute Name</label>
+<div class="invalid-feedback"></div>
+
+</div>
+</div>
+HTML;
+        $this->assertEqualsWithoutLE($expectedHtml, $html);
+    }
+
+    public function testDefaultCheckboxListByConfig()
+    {
+        Html::$counter = 0;
+        $html = $this->_activeField->checkboxList([1 => 'name1', 2 => 'name2'])->render();
+
+        $expectedHtml = <<<HTML
+<div class="form-group field-dynamicmodel-attributename">
+<label>Attribute Name</label>
+<input type="hidden" name="DynamicModel[attributeName]" value=""><div id="dynamicmodel-attributename"><div class="form-check">
+<input type="checkbox" id="i0" class="form-check-input" name="DynamicModel[attributeName][]" value="1">
+<label class="form-check-label" for="i0">name1</label>
+</div>
+
+<div class="form-check">
+<input type="checkbox" id="i1" class="form-check-input" name="DynamicModel[attributeName][]" value="2">
+<label class="form-check-label" for="i1">name2</label>
+<div class="invalid-feedback"></div>
+</div>
+</div>
+
+</div>
+HTML;
+        $this->assertEqualsWithoutLE($expectedHtml, $html);
+    }
+
+    public function testDefaultRadioListByConfig()
+    {
+        Html::$counter = 0;
+        $html = $this->_activeField->radioList([1 => 'name1', 2 => 'name2'])->render();
+
+        $expectedHtml = <<<HTML
+<div class="form-group field-dynamicmodel-attributename">
+<label>Attribute Name</label>
+<input type="hidden" name="DynamicModel[attributeName]" value=""><div id="dynamicmodel-attributename" role="radiogroup"><div class="form-check">
+<input type="radio" id="i0" class="form-check-input" name="DynamicModel[attributeName]" value="1">
+<label class="form-check-label" for="i0">name1</label>
+</div>
+
+<div class="form-check">
+<input type="radio" id="i1" class="form-check-input" name="DynamicModel[attributeName]" value="2">
+<label class="form-check-label" for="i1">name2</label>
+<div class="invalid-feedback"></div>
+</div>
+</div>
+
+</div>
+HTML;
+        $this->assertEqualsWithoutLE($expectedHtml, $html);
+    }
+
+    public function testHorizontalLayout()
+    {
+        Html::$counter = 0;
+        ActiveForm::$counter = 0;
+        ob_start();
+        $model = new DynamicModel(['attributeName', 'checkbox', 'gridRadios']);
+        $form = ActiveForm::begin([
+            'action' => '/some-action',
+            'layout' => ActiveForm::LAYOUT_HORIZONTAL
+        ]);
+        echo $form->field($model, 'attributeName');
+        echo $form->field($model, 'checkbox')->checkbox(['wrapperOptions' => ['class' => ['widget' => new UnsetArrayValue()]]]);
+        echo $form->field($model, 'gridRadios')->radioList([
+            'option1' => 'First radio',
+            'option2' => 'Second radio',
+            'option3' => 'Third radio'
+        ]);
+        ActiveForm::end();
+        $out = ob_get_clean();
+
+        $expected = <<<HTML
+<div class="form-group row field-dynamicmodel-attributename">
+<label class="col-sm-2 col-form-label" for="dynamicmodel-attributename">Attribute Name</label>
+<div class="col-sm-10">
+<input type="text" id="dynamicmodel-attributename" class="form-control" name="DynamicModel[attributeName]">
+<div class="invalid-feedback "></div>
+
+</div>
+</div>
+HTML;
+        $expected2 = <<<HTML
+<div class="form-group row field-dynamicmodel-checkbox">
+<div class="col-sm-10 offset-sm-2">
+<div class="form-check">
+<input type="hidden" name="DynamicModel[checkbox]" value="0"><input type="checkbox" id="dynamicmodel-checkbox" class="form-check-input" name="DynamicModel[checkbox]" value="1">
+<label class="form-check-label" for="dynamicmodel-checkbox">Checkbox</label>
+<div class="invalid-feedback "></div>
+
+</div>
+</div>
+</div>
+HTML;
+        $expected3 = <<<HTML
+<div class="form-group row field-dynamicmodel-gridradios">
+<label class="col-sm-2 col-form-label">Grid Radios</label>
+<div class="col-sm-10">
+<input type="hidden" name="DynamicModel[gridRadios]" value=""><div id="dynamicmodel-gridradios" role="radiogroup"><div class="form-check">
+<input type="radio" id="i0" class="form-check-input" name="DynamicModel[gridRadios]" value="option1">
+<label class="form-check-label" for="i0">First radio</label>
+</div>
+
+<div class="form-check">
+<input type="radio" id="i1" class="form-check-input" name="DynamicModel[gridRadios]" value="option2">
+<label class="form-check-label" for="i1">Second radio</label>
+</div>
+
+<div class="form-check">
+<input type="radio" id="i2" class="form-check-input" name="DynamicModel[gridRadios]" value="option3">
+<label class="form-check-label" for="i2">Third radio</label>
+<div class="invalid-feedback "></div>
+</div>
+</div>
+
+</div>
+</div>
+HTML;
+
+
+        $this->assertContains($expected, $out);
+        $this->assertContains($expected2, $out);
+        $this->assertContains($expected3, $out);
+    }
+}

--- a/tests/ActiveFieldTest.php
+++ b/tests/ActiveFieldTest.php
@@ -5,6 +5,7 @@ namespace yiiunit\extensions\bootstrap4;
 use yii\base\DynamicModel;
 use yii\bootstrap4\ActiveField;
 use yii\bootstrap4\ActiveForm;
+use yii\bootstrap4\Html;
 
 class ActiveFieldTest extends TestCase
 {
@@ -46,6 +47,7 @@ class ActiveFieldTest extends TestCase
 
     public function testFileInput()
     {
+        Html::$counter = 0;
         $html = $this->activeField->fileInput()->render();
 
         $expectedHtml = <<<HTML
@@ -64,6 +66,7 @@ HTML;
 
     public function testRadioList()
     {
+        Html::$counter = 0;
         $html = $this->activeField->radioList([1 => 'name1', 2 => 'name2'])->render();
 
         $expectedHtml = <<<HTML
@@ -88,7 +91,7 @@ HTML;
 
     public function testCheckboxList()
     {
-        \yii\bootstrap4\Html::$counter = 0;
+        Html::$counter = 0;
         $html = $this->activeField->checkboxList([1 => 'name1', 2 => 'name2'])->render();
 
         $expectedHtml = <<<HTML
@@ -113,7 +116,7 @@ HTML;
 
     public function testRadioListInline()
     {
-        \yii\bootstrap4\Html::$counter = 0;
+        Html::$counter = 0;
         $this->activeField->inline = true;
         $html = $this->activeField->radioList([1 => 'name1', 2 => 'name2'])->render();
 
@@ -139,7 +142,7 @@ HTML;
 
     public function testCheckboxListInline()
     {
-        \yii\bootstrap4\Html::$counter = 0;
+        Html::$counter = 0;
         $this->activeField->inline = true;
         $html = $this->activeField->checkboxList([1 => 'name1', 2 => 'name2'])->render();
 
@@ -170,6 +173,7 @@ HTML;
      */
     public function testRadioListItemOptions()
     {
+        Html::$counter = 0;
         $content = $this->activeField->radioList([1 => 'name1', 2 => 'name2'], [
             'itemOptions' => [
                 'data-attribute' => 'test'
@@ -186,6 +190,7 @@ HTML;
      */
     public function testCheckboxListItemOptions()
     {
+        Html::$counter = 0;
         $content = $this->activeField->checkboxList([1 => 'name1', 2 => 'name2'], [
             'itemOptions' => [
                 'data-attribute' => 'test'
@@ -200,7 +205,7 @@ HTML;
      */
     public function testCustomRadio()
     {
-        \yii\bootstrap4\Html::$counter = 0;
+        Html::$counter = 0;
         $this->activeField->inline = true;
         $html = $this->activeField->radio()->render();
 
@@ -222,7 +227,7 @@ HTML;
      */
     public function testCustomCheckbox()
     {
-        \yii\bootstrap4\Html::$counter = 0;
+        Html::$counter = 0;
         $this->activeField->inline = true;
         $html = $this->activeField->checkbox()->render();
 


### PR DESCRIPTION
Introduced `$checkOptions` to make checkboxes fully configurable via widget factory.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️ 
| New feature?  | ✔️ 
| Breaks BC?    | ❌ 
| Tests pass?   | ✔️ 
| Fixed issues  | #165

I'm not sure if this is the best way to go. But it would make it possible to override all classes via config like this:
```php
$config = [
    'id' => 'basic',
    'basePath' => dirname(__DIR__),
    'extensions' => require __DIR__ . '/../vendor/yiisoft/extensions.php',
    'container' => [
        'definitions' => [
            'yii\bootstrap4\ActiveField' => [
                'checkTemplate' => "<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>",
                'radioTemplate' => "<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>",
                'checkHorizontalTemplate' => "{beginWrapper}\n<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>\n{endWrapper}",
                'radioHorizontalTemplate' => "{beginWrapper}\n<div class=\"form-check\">\n{input}\n{label}\n{error}\n{hint}\n</div>\n{endWrapper}",
                'checkOptions' => [
                    'class' => ['widget' => 'form-check-input'],
                    'labelOptions' => [
                        'class' => ['widget' => 'form-check-label']
                    ],
                    'wrapperOptions' => [
                        'class' => ['widget' => 'form-check']
                    ]
                ]
            ]
        ]
    ]
];
```
