### PR TITLE
Fix #171: Custom radio|checkbox inline error

### DIFF
--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -344,10 +344,10 @@ class ActiveField extends \yii\widgets\ActiveField
 
                 $html = Html::beginTag('div', $wrapperOptions) . "\n" .
                     Html::checkbox($name, $checked, $options) . "\n";
+                $html .= Html::endTag('div') . "\n";
                 if ($itemCount === $i) {
                     $html .= $error . "\n";
                 }
-                $html .= Html::endTag('div') . "\n";
 
                 return $html;
             };
@@ -385,10 +385,10 @@ class ActiveField extends \yii\widgets\ActiveField
 
                 $html = Html::beginTag('div', $wrapperOptions) . "\n" .
                     Html::radio($name, $checked, $options) . "\n";
+                $html .= Html::endTag('div') . "\n";
                 if ($itemCount === $i) {
                     $html .= $error . "\n";
                 }
-                $html .= Html::endTag('div') . "\n";
 
                 return $html;
             };


### PR DESCRIPTION
Fixed issue #171 

Moved element out of div.custom-control

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #171 
