### PR TITLE
Update Button.php to simply use glyphicons

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -15,6 +15,7 @@ namespace yii\bootstrap4;
  * ```php
  * echo Button::widget([
  *     'label' => 'Action',
+ *     'icon' => 'play-circle',
  *     'options' => ['class' => 'btn-lg'],
  * ]);
  * ```
@@ -31,6 +32,10 @@ class Button extends Widget
      * @var string the button label
      */
     public $label = 'Button';
+    /**
+    * @var string the button icon
+    */
+    public $icon = '';
     /**
      * @var bool whether the label should be HTML-encoded.
      */
@@ -54,7 +59,10 @@ class Button extends Widget
     public function run()
     {
         $this->registerPlugin('button');
-        return Html::tag($this->tagName, $this->encodeLabel ? Html::encode($this->label) : $this->label,
+        if(empty($this->icon)){
+            $icon = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>';
+        }    
+        return Html::tag($this->tagName, $this->encodeLabel ? $icon . Html::encode($this->label) : $icon . $this->label,
             $this->options);
     }
 }

--- a/src/Button.php
+++ b/src/Button.php
@@ -59,6 +59,7 @@ class Button extends Widget
     public function run()
     {
         $this->registerPlugin('button');
+        $icon = '';
         if(!empty($this->icon)){
             $icon = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>';
         }    

--- a/src/Button.php
+++ b/src/Button.php
@@ -59,7 +59,7 @@ class Button extends Widget
     public function run()
     {
         $this->registerPlugin('button');
-        if(empty($this->icon)){
+        if(!empty($this->icon)){
             $icon = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>';
         }    
         return Html::tag($this->tagName, $this->encodeLabel ? $icon . Html::encode($this->label) : $icon . $this->label,


### PR DESCRIPTION
After this change you can choose an icon just typing its glyphicons' name.

Example:
echo Button::widget([
      'label' => 'Action',
      'icon' => 'play-circle',  
      'options' => ['class' => 'btn-lg'],
  ]);

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | ...