### PR TITLE
Fix typo in `Nav` docblock

### DIFF
--- a/src/Nav.php
+++ b/src/Nav.php
@@ -39,11 +39,11 @@ use Yii;
  *             'visible' => Yii::$app->user->isGuest
  *         ],
  *     ],
- *     'options' => ['class' =>'nav-pills'], // set this to nav-tab to get tab-styled navigation
+ *     'options' => ['class' =>'nav-pills'], // set this to nav-tabs to get tab-styled navigation
  * ]);
  * ```
  *
- * Note: Multilevel dropdowns beyond Level 1 are not supported in Bootstrap 3.
+ * Note: Multilevel dropdowns beyond Level 1 are not supported in Bootstrap 4.
  *
  * @see http://getbootstrap.com/components/#dropdowns
  * @see http://getbootstrap.com/components/#nav


### PR DESCRIPTION
The tab-style navigation in Bootstrap 4 is activated via `nav-tabs` not
`nav-tab`.
See https://getbootstrap.com/docs/4.0/components/navs/#tabs

Additionally, this widget is for _Bootstrap 4_, not 3. Seems to still
not support multi-level dropdowns in `nav` elements.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes (semver would probably say bugfix)
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

