### PR TITLE
Updated reference link to the Bootstrap 4 Buttons

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -18,7 +18,7 @@ namespace yii\bootstrap4;
  *     'options' => ['class' => 'btn-lg'],
  * ]);
  * ```
- * @see http://getbootstrap.com/javascript/#buttons
+ * @see https://getbootstrap.com/docs/4.5/components/buttons/
  * @author Antonio Ramirez <amigo.cobos@gmail.com>
  */
 class Button extends Widget


### PR DESCRIPTION
At present, the link provided in the Doc Block is redirecting to Bootstrap 3 buttons. Changed the link to Bootstrap's latest Button Documentation.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
