### PR TITLE
Nav::init method default css class fix

### DIFF
--- a/src/Nav.php
+++ b/src/Nav.php
@@ -117,7 +117,7 @@ class Nav extends Widget
         if ($this->params === null) {
             $this->params = Yii::$app->request->getQueryParams();
         }
-        Html::addCssClass($this->options, ['widget' => 'nav']);
+        Html::addCssClass($this->options, ['widget' => 'navbar-nav']);
     }
 
     /**

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -141,7 +141,7 @@ class Tabs extends Widget
     public function init()
     {
         parent::init();
-        Html::addCssClass($this->options, ['widget' => 'nav', $this->navType]);
+        Html::addCssClass($this->options, ['widget' => 'navbar-nav', $this->navType]);
         Html::addCssClass($this->tabContentOptions, ['panel' => 'tab-content']);
     }
 

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -111,7 +111,7 @@ HTML;
 <a class="navbar-brand" href="/">My Company</a>
 <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
 <div id="w0-collapse" class="collapse navbar-collapse">
-<ul id="w1" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
+<ul id="w1" class="mr-auto navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
 <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Dropdown</a><div id="w2" class="dropdown-menu"><a class="dropdown-item" href="#">Action</a>
 <a class="dropdown-item" href="#">Another action</a>

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -60,7 +60,7 @@ class NavTest extends TestCase
         );
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Dropdown1</a><div id="w1" class="dropdown-menu"><h6 class="dropdown-header">Page2</h6>
 <h6 class="dropdown-header">Page3</h6></div></li></ul>
 EXPECTED;
@@ -99,7 +99,7 @@ EXPECTED;
         );
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Dropdown1</a><div id="test1" class="test dropdown-menu" data-id="t1"><h6 class="dropdown-header">Page2</h6>
 <h6 class="dropdown-header">Page3</h6></div></li></ul>
 EXPECTED;
@@ -131,7 +131,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Dropdown1</a><div id="w1" class="dropdown-menu"><h6 class="dropdown-header">Page2</h6>
 <h6 class="dropdown-header">Page3</h6></div></li>
 <li class="nav-item"><a class="nav-link" href="#">Page4</a></li></ul>
@@ -163,7 +163,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="/base/index.php?r=site%2Findex">Main</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="/base/index.php?r=site%2Findex">Main</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Admin</a><div id="w1" class="dropdown-menu"><a class="dropdown-item active" href="/base/index.php?r=site%2Fusers">Users</a>
 <a class="dropdown-item" href="/base/index.php?r=site%2Froles">Roles</a>
 <a class="dropdown-item" href="/base/index.php?r=site%2Fstatuses">Statuses</a></div></li></ul>
@@ -196,7 +196,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
 <li class="nav-item"><a class="nav-link" href="/base/index.php?r=site%2Findex">Item2</a></li></ul>
 EXPECTED;
 
@@ -226,7 +226,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link active" href="#">Item1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link active" href="#">Item1</a></li>
 <li class="nav-item"><a class="nav-link active" href="/base/index.php?r=site%2Findex">Item2</a></li></ul>
 EXPECTED;
 
@@ -259,7 +259,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Item2</a><div id="w1" class="dropdown-menu"><a class="dropdown-item" href="/base/index.php?r=site%2Findex">Page2</a>
 <h6 class="dropdown-header">Page3</h6></div></li></ul>
 EXPECTED;
@@ -292,7 +292,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Item2</a><div id="w1" class="dropdown-menu"><a class="dropdown-item active" href="/base/index.php?r=site%2Findex">Page2</a>
 <h6 class="dropdown-header">Page3</h6></div></li></ul>
 EXPECTED;
@@ -323,7 +323,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="nav-item"><a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Item1</a></li>
+<ul id="w0" class="navbar-nav"><li class="nav-item"><a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Item1</a></li>
 <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-toggle="dropdown">Item2</a><div id="w1" class="dropdown-menu"><a class="dropdown-item disabled" href="/base/index.php?r=site%2Findex" tabindex="-1" aria-disabled="true">Page2</a>
 <h6 class="dropdown-header">Page3</h6></div></li></ul>
 EXPECTED;
@@ -357,7 +357,7 @@ EXPECTED;
         ]);
 
         $expected = <<<EXPECTED
-<ul id="w0" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active" href="#" data-toggle="dropdown">Dropdown</a><div id="w1" class="dropdown-menu"><div class="dropdown active" aria-expanded="false">
+<ul id="w0" class="navbar-nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active" href="#" data-toggle="dropdown">Dropdown</a><div id="w1" class="dropdown-menu"><div class="dropdown active" aria-expanded="false">
 <a class="dropdown-item dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Sub-dropdown</a>
 <div id="w2" class="dropdown-submenu dropdown-menu"><h6 class="dropdown-header">Page</h6></div>
 </div></div></li></ul>

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -28,7 +28,7 @@ class TabsTest extends TestCase
             ]
         ]);
 
-        $this->assertContains('<ul id="w0" class="nav nav-tabs" role="tablist">', $out);
+        $this->assertContains('<ul id="w0" class="navbar-nav nav-tabs" role="tablist">', $out);
     }
 
     /**
@@ -362,7 +362,7 @@ class TabsTest extends TestCase
         ]);
 
         $expected = <<<HTML
-<ul id="w0" class="nav nav-tabs" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li>
+<ul id="w0" class="navbar-nav nav-tabs" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li>
 <li class="nav-item"><a class="nav-link" href="#w0-tab1" data-toggle="tab" role="tab" aria-controls="w0-tab1" aria-selected="false">Tab 2</a></li></ul>
 <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div>
 <div id="w0-tab1" class="tab-pane"><div>Content 2</div></div></div>

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -396,7 +396,7 @@ HTML;
         ]);
 
         $expected = <<<HTML
-<ul id="w0" class="row nav nav-tabs" role="tablist"><li class="col nav-item"><a class="nav-link active" href="#w0-tab0" data-toggle="tab" role="tab" aria-controls="w0-tab0" aria-selected="true">Tab 1</a></li>
+<ul id="w0" class="row navbar-nav nav-tabs" role="tablist"><li class="col nav-item"><a class="nav-link active" href="#w0-tab0" data-toggle="tab" role="tab" aria-controls="w0-tab0" aria-selected="true">Tab 1</a></li>
 <li class="col-6 nav-item"><a class="nav-link" href="#w0-tab1" data-toggle="tab" role="tab" aria-controls="w0-tab1" aria-selected="false">Tab 2</a></li>
 <li class="col-3 nav-item"><a class="nav-link" href="http://www.example.com/">Link</a></li></ul>
 <div class="tab-content"><div id="w0-tab0" class="tab-pane active"><div>Content 1</div></div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no

## Brief: 
Small bug fix, discussed on forum: https://forum.yiiframework.com/t/bootstrap-4-migration-navbar-nav-items-align-problem/130917

## What steps will reproduce the problem?:
The Nav::init method adds wrong css class '.nav' to the produced 'ul' element.

## What's expected?
Nav::init method adds correct class '.navbar-nav' 



