### PR TITLE
Fix: Show error on empty checkboxList/radioList field

### DIFF
--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -321,7 +321,7 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public function checkboxList($items, $options = [])
     {
-        if (!isset($options['item'])) {
+        if (!isset($options['item']) && !empty($items)) {
             $this->template = str_replace("\n{error}", '', $this->template);
             $itemOptions = isset($options['itemOptions']) ? $options['itemOptions'] : [];
             $encode = ArrayHelper::getValue($options, 'encode', true);
@@ -362,7 +362,7 @@ class ActiveField extends \yii\widgets\ActiveField
      */
     public function radioList($items, $options = [])
     {
-        if (!isset($options['item'])) {
+        if (!isset($options['item']) && !empty($items)) {
             $this->template = str_replace("\n{error}", '', $this->template);
             $itemOptions = isset($options['itemOptions']) ? $options['itemOptions'] : [];
             $encode = ArrayHelper::getValue($options, 'encode', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no

If an error occurs on an empty checboxList/radioList field, no error message is displayed, since the current implementation of error output in yii2-bootstrap4 is bound to the last displayed item. This fix disables the logic of replacing a field template if the list is empty.