### PR TITLE
Fix name of method ActiveField::dropDownList()

### DIFF
--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -415,13 +415,13 @@ class ActiveField extends \yii\widgets\ActiveField
     /**
      * {@inheritdoc}
      */
-    public function dropdownList($items, $options = [])
+    public function dropDownList($items, $options = [])
     {
         if ($this->form->layout === ActiveForm::LAYOUT_INLINE) {
             Html::removeCssClass($this->labelOptions, 'sr-only');
         }
 
-        return parent::dropdownList($items, $options);
+        return parent::dropDownList($items, $options);
     }
 
     /**


### PR DESCRIPTION
Same as in https://github.com/yiisoft/yii2-bootstrap5/pull/22

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
