### PR TITLE
Checkbox labels should not be hidden in inline forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 ------------------------
 
 - Enh #237: Added `Accordion::headerToggleOptions` (nagyt234)
+- Bug #243: Checkbox labels in inline forms are no longer hidden (BBoom)
 
 2.0.11 May 22, 2023
 -------------------

--- a/src/ActiveField.php
+++ b/src/ActiveField.php
@@ -269,6 +269,9 @@ class ActiveField extends \yii\widgets\ActiveField
             Html::removeCssClass($this->labelOptions, $this->horizontalCssClasses['label']);
             Html::addCssClass($this->wrapperOptions, $this->horizontalCssClasses['offset']);
         }
+        if ($this->form->layout === ActiveForm::LAYOUT_INLINE) {
+            Html::removeCssClass($this->labelOptions, 'sr-only');
+        }
         unset($options['template']);
 
         if ($enclosedByLabel) {

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -194,7 +194,7 @@ HTML;
 <div class="form-group field-dynamicmodel-checkboxname">
 <div class="custom-control custom-checkbox">
 <input type="hidden" name="DynamicModel[checkboxName]" value="0"><input type="checkbox" id="dynamicmodel-checkboxname" class="custom-control-input" name="DynamicModel[checkboxName]" value="1">
-<label class="sr-only custom-control-label" for="dynamicmodel-checkboxname">Checkbox Name</label>
+<label class="custom-control-label" for="dynamicmodel-checkboxname">Checkbox Name</label>
 
 
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Inline forms by default hide all labels with the sr-only class. This should not happen for checkbox elements, which need their label to function. Without a visible label, the checkbox will not function in bootstrap. And even if it did, a checkbox without a label is not really usable.

The method for class removal is based on similar exceptions made in the listBox() and dropDownList() methods in the same class.