### PR TITLE
Fix `LinkPager::getPageRange` when `maxButtons` assign with 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 ------------------------
 
 - Enh #246: Remove unnecessary files from Composer package (@s1lver)
+- Bug #247: Fix `LinkPager::getPageRange` when `maxButtons` assign with 2 (max-s-lab)
 
 
 2.0.12 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 bootstrap4 extension Change Log
 ------------------------
 
 - Enh #246: Remove unnecessary files from Composer package (@s1lver)
-- Bug #247: Fix `LinkPager::getPageRange` when `maxButtons` assign with 2 (max-s-lab)
+- Bug #247: Fix `LinkPager::getPageRange` when `maxButtons` is 2 (max-s-lab)
 
 
 2.0.12 February 13, 2025

--- a/src/LinkPager.php
+++ b/src/LinkPager.php
@@ -305,7 +305,9 @@ class LinkPager extends Widget
         $currentPage = $this->pagination->getPage();
         $pageCount = $this->pagination->getPageCount();
 
-        $beginPage = max(0, $currentPage - (int)($this->maxButtonCount / 2));
+        $beginPageOffset = $this->maxButtonCount > 2 ? (int) ($this->maxButtonCount / 2) : 0;
+        $beginPage = max(0, $currentPage - $beginPageOffset);
+
         if (($endPage = $beginPage + $this->maxButtonCount - 1) >= $pageCount) {
             $endPage = $pageCount - 1;
             $beginPage = max(0, $endPage - $this->maxButtonCount + 1);

--- a/tests/LinkPagerTest.php
+++ b/tests/LinkPagerTest.php
@@ -144,34 +144,32 @@ class LinkPagerTest extends TestCase
             'maxButtonCount' => 2,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
-            <li class="page-item"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
+<li class="page-item"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
 
         $output = LinkPager::widget([
             'pagination' => $this->getPagination(1),
             'maxButtonCount' => 2,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
-            <li class="page-item"><a class="page-link" href="/?r=test&amp;page=3" data-page="2">3</a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+<li class="page-item"><a class="page-link" href="/?r=test&amp;page=3" data-page="2">3</a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
     }
 
     public function testWithOneButton()
@@ -181,32 +179,30 @@ class LinkPagerTest extends TestCase
             'maxButtonCount' => 1,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
 
         $output = LinkPager::widget([
             'pagination' => $this->getPagination(1),
             'maxButtonCount' => 1,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
     }
 
     public function testWithNoButtons()
@@ -216,30 +212,28 @@ class LinkPagerTest extends TestCase
             'maxButtonCount' => 0,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
 
         $output = LinkPager::widget([
             'pagination' => $this->getPagination(1),
             'maxButtonCount' => 0,
         ]);
 
-        $this->assertContainsWithoutLE(
-            <<<HTML
-            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span></a></li>
-            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span></a></li></ul>
-            HTML,
-            $output
-        );
+        $expected = <<<HTML
+<ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+<span class="sr-only">Previous</span></a></li>
+<li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+<span class="sr-only">Next</span></a></li></ul>
+HTML;
+
+        $this->assertContainsWithoutLE($expected, $output);
     }
 
     /**

--- a/tests/LinkPagerTest.php
+++ b/tests/LinkPagerTest.php
@@ -153,7 +153,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
 
         $output = LinkPager::widget([
@@ -170,7 +170,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
     }
 
@@ -189,7 +189,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
 
         $output = LinkPager::widget([
@@ -205,7 +205,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
     }
 
@@ -223,7 +223,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
 
         $output = LinkPager::widget([
@@ -238,7 +238,7 @@ class LinkPagerTest extends TestCase
             <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span></a></li></ul>
             HTML,
-            $output,
+            $output
         );
     }
 

--- a/tests/LinkPagerTest.php
+++ b/tests/LinkPagerTest.php
@@ -137,6 +137,111 @@ class LinkPagerTest extends TestCase
         );
     }
 
+    public function testWithTwoButtons()
+    {
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(0),
+            'maxButtonCount' => 2,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
+            <li class="page-item"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(1),
+            'maxButtonCount' => 2,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+            <li class="page-item"><a class="page-link" href="/?r=test&amp;page=3" data-page="2">3</a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+    }
+
+    public function testWithOneButton()
+    {
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(0),
+            'maxButtonCount' => 1,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=1" data-page="0">1</a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(1),
+            'maxButtonCount' => 1,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item active"><a class="page-link" href="/?r=test&amp;page=2" data-page="1">2</a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+    }
+
+    public function testWithNoButtons()
+    {
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(0),
+            'maxButtonCount' => 0,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev disabled"><a class="page-link" href="/?r=test&amp;page=1" data-page="0" tabindex="-1"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=2" data-page="1"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+
+        $output = LinkPager::widget([
+            'pagination' => $this->getPagination(1),
+            'maxButtonCount' => 0,
+        ]);
+
+        $this->assertContainsWithoutLE(
+            <<<HTML
+            <ul class="pagination"><li class="page-item prev"><a class="page-link" href="/?r=test&amp;page=1" data-page="0"><span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span></a></li>
+            <li class="page-item next"><a class="page-link" href="/?r=test&amp;page=3" data-page="2"><span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span></a></li></ul>
+            HTML,
+            $output,
+        );
+    }
+
     /**
      * @see https://github.com/yiisoft/yii2/issues/15536
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/yii2/issues/19655

Copied the fix from here: https://github.com/yiisoft/yii2/pull/20538